### PR TITLE
Integer (index) als worksheet option

### DIFF
--- a/src/Controller/Component/ImportComponent.php
+++ b/src/Controller/Component/ImportComponent.php
@@ -69,8 +69,10 @@ class ImportComponent extends Component
 
             if (count($worksheets) === 1) {
                 $worksheetToLoad = $worksheets[0];  //first option: if there is only one worksheet, use it
+            } elseif (isset($options['worksheet']) && is_int($options['worksheet']) && isset($worksheets[$options['worksheet']])) {
+                $worksheetToLoad = $worksheets[$options['worksheet']]; //second option: select a fixed worksheet index
             } elseif (isset($options['worksheet'])) {
-                $worksheetToLoad = $options['worksheet']; //second option: desired worksheet was provided as option
+                $worksheetToLoad = $options['worksheet']; //third option: desired worksheet was provided as option
             } else {
                 $worksheetToLoad = $this->_registry->getController()->name; //last option: try to load worksheet with the name of current controller
             }


### PR DESCRIPTION
Would be nice to implement the option 'worksheet' to handle integers (indexes) as well. This allows users to upload excel files using any number of sheets with variable names. E.g.

```
$data = $this->Import->prepareEntityData($this->request->data['filename']['tmp_name'], [
    'worksheet' => 0
]);
```